### PR TITLE
Vagrantfile fixes for vagrant 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,36 @@ This packer template requires to variables to be set either via command line or 
 
 1. `iso_file` - is the photon ISO for the build (can be local or remote).
 1. `iso_sha1sum` - is the SHA1 sum of the ISO you want to build.
+1. `product_version` - is the PhotonOS release version (will be added to the image filename)
 
-To kick off a full build:
+Preset JSONs with the required parameters are provided in vars folder.
 
+To kick off a full build using a preset:
+
+```shell
+packer build -var-file=vars/iso-2.0GA.json packer-photon.json
+```
+
+or manually:
 ```shell
 packer build \
         -var 'iso_file=https://bintray.com/artifact/download/vmware/photon/iso/1.0TP2/x86_64/photon-minimal-1.0TP2.iso' \
         -var 'iso_sha1sum=a47567368458acd8c8ef5f1e3f793c5329063dac' \
+        -var 'product_version=1.0TP2' \
         packer-photon.json
 ```
 
-To build only a subset:
-
+To build only a VMware workstation/fusion vagrant box:
+```shell
+packer build -only=vagrant-vmware_desktop -var-file=vars/iso-2.0GA.json packer-photon.json
+```
+or:
 ```shell
 packer build \
-       -only=<build target>,<build target> \
+       -only=vagrant-vmware_desktop \
        -var 'iso_file=https://bintray.com/artifact/download/vmware/photon/iso/1.0TP2/x86_64/photon-minimal-1.0TP2.iso' \
        -var 'iso_sha1sum=a47567368458acd8c8ef5f1e3f793c5329063dac' \
+       -var 'product_version=1.0TP2' \
        packer-photon.json
 ```
 

--- a/packer-photon.json
+++ b/packer-photon.json
@@ -2,6 +2,7 @@
   "variables": {
     "iso_file": "",
     "iso_sha1sum": "",
+    "product_version": "",
     "root_password": "2RQrZ83i79N6szpvZNX6"
   },
   "builders": [
@@ -99,6 +100,10 @@
     {
       "type": "shell",
       "script": "scripts/photon-security_check.sh"
+    },
+    {
+      "type": "shell",
+      "inline": ["sed -i 's/OS/Linux/' /etc/photon-release"]
     }
   ],
   "post-processors": [
@@ -107,7 +112,7 @@
       "only": ["vagrant-vmware_desktop", "vagrant-virtualbox"],
       "compression_level": 9,
       "vagrantfile_template": "scripts/photon-vagrantfile.rb",
-      "output": "photon-{{.BuildName}}.box"
+      "output": "photon-{{user `product_version`}}-{{.BuildName}}.box"
     }
   ]
   }

--- a/scripts/photon-vagrantfile.rb
+++ b/scripts/photon-vagrantfile.rb
@@ -4,11 +4,13 @@ Vagrant.configure('2') do |config|
   # We don't have NFS working inside Photon.
   config.nfs.functional = false
 
-  %w('vmware_fusion', 'vmware_workstation', 'vmware_appcatalyst').each do |p|
+  ['vmware_fusion', 'vmware_workstation', 'vmware_appcatalyst'].each do |p|
     config.vm.provider p do |v|
       # Use paravirtualized virtual hardware on VMW hypervisors
       v.vmx['ethernet0.virtualDev'] = 'vmxnet3'
       v.vmx['scsi0.virtualDev'] = 'pvscsi'
+      # persistent device naming whitelist
+      v.whitelist_verified = true
     end
   end
   config.vm.provider "virtualbox" do |v|

--- a/vars/iso-2.0GA.json
+++ b/vars/iso-2.0GA.json
@@ -1,0 +1,5 @@
+{
+   "product_version" : "2.0GA",
+   "iso_sha1sum" : "68ec892a66e659b18917a12738176bd510cde829",
+   "iso_file" : "http://dl.bintray.com/vmware/photon/2.0/GA/iso/photon-2.0-304b817.iso"
+}


### PR DESCRIPTION
- Fix the array, it does not work at all otherwise.
- Add persistent device naming whitelist flag (vagrant warning)

- Add a crutch for changes in /etc/photon-release that conflict with vagrant plugin detection
- New vars folder with jsons for ease of building images