### PR TITLE
chore(deps): bump virtualbox 6.1.32 to 6.1.40

### DIFF
--- a/override.pkrvars.hcl
+++ b/override.pkrvars.hcl
@@ -2,8 +2,8 @@
 
 # os_packagelist           = "minimal"
 # vm_name                  = "photon"
-# guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.32/VBoxGuestAdditions_6.1.32.iso"
-# guest_additions_checksum = "3ab8d64c209d89ffc48e71df68ac0da2cf76074579ffaf2dba008ddbef44129c"
+# guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.40/VBoxGuestAdditions_6.1.40.iso"
+# guest_additions_checksum = "d456c559926f1a8fdd7259056e0a50f12339fd494122cf30db7736e2032970c6"
 # ssh_password             = "VMw@re123!"
 # ssh_timeout              = "15m"
 # boot_wait                = "3s"

--- a/photon-3.0-R3.pkrvars.hcl
+++ b/photon-3.0-R3.pkrvars.hcl
@@ -6,5 +6,5 @@ iso_checksum_value = "b3cac3a62659261af7ede1cbb81d5af544a26d19"
 iso_url            = "https://packages.vmware.com/photon/3.0/Rev3/iso/photon-3.0-a383732.iso"
 
 // VirtualBox Guest 
-guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.32/VBoxGuestAdditions_6.1.32.iso"
-guest_additions_checksum = "3ab8d64c209d89ffc48e71df68ac0da2cf76074579ffaf2dba008ddbef44129c"
+guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.40/VBoxGuestAdditions_6.1.40.iso"
+guest_additions_checksum = "d456c559926f1a8fdd7259056e0a50f12339fd494122cf30db7736e2032970c6"

--- a/photon-4.0-GA.pkrvars.hcl
+++ b/photon-4.0-GA.pkrvars.hcl
@@ -6,5 +6,5 @@ iso_checksum_value = "2221ab214b517a15c60bd5e2aacdb9388581bcd9"
 iso_url            = "https://packages.vmware.com/photon/4.0/GA/iso/photon-4.0-1526e30ba.iso"
 
 // VirtualBox Guest 
-guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.32/VBoxGuestAdditions_6.1.32.iso"
-guest_additions_checksum = "3ab8d64c209d89ffc48e71df68ac0da2cf76074579ffaf2dba008ddbef44129c"
+guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.40/VBoxGuestAdditions_6.1.40.iso"
+guest_additions_checksum = "d456c559926f1a8fdd7259056e0a50f12339fd494122cf30db7736e2032970c6"

--- a/photon-4.0-R1.pkrvars.hcl
+++ b/photon-4.0-R1.pkrvars.hcl
@@ -6,5 +6,5 @@ iso_checksum_value = "bec6359661b43ff15ac02b037f8028ae116dadb3"
 iso_url            = "https://packages.vmware.com/photon/4.0/Rev1/iso/photon-4.0-ca7c9e933.iso"
 
 // VirtualBox Guest 
-guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.32/VBoxGuestAdditions_6.1.32.iso"
-guest_additions_checksum = "3ab8d64c209d89ffc48e71df68ac0da2cf76074579ffaf2dba008ddbef44129c"
+guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.40/VBoxGuestAdditions_6.1.40.iso"
+guest_additions_checksum = "d456c559926f1a8fdd7259056e0a50f12339fd494122cf30db7736e2032970c6"

--- a/photon-4.0-R2.pkrvars.hcl
+++ b/photon-4.0-R2.pkrvars.hcl
@@ -6,5 +6,5 @@ iso_checksum_value = "eeb08738209bf77306268d63b834fd91f6cecdfb"
 iso_url            = "https://packages.vmware.com/photon/4.0/Rev2/iso/photon-4.0-c001795b8.iso"
 
 // VirtualBox Guest 
-guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.32/VBoxGuestAdditions_6.1.32.iso"
-guest_additions_checksum = "3ab8d64c209d89ffc48e71df68ac0da2cf76074579ffaf2dba008ddbef44129c"
+guest_additions_url      = "https://download.virtualbox.org/virtualbox/6.1.40/VBoxGuestAdditions_6.1.40.iso"
+guest_additions_checksum = "d456c559926f1a8fdd7259056e0a50f12339fd494122cf30db7736e2032970c6"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/photon-packer-templates/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Bumps VirtualBox from 6.1.31 to 6.1.40.

> **Note**
> Will later update to VirtualBox 7.0 after testing with Vagrant 2.3.2.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is something else.
      Please describe: `chore`

**Context of the Pull Request***

<!--
    Please describe the current behavior that you are modifying or link to a relevant issue.
-->

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [x] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
